### PR TITLE
Allow filtering single_value mappings

### DIFF
--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -57,6 +57,17 @@ A suggested way to organize this is by creating the config file and launch file 
 
 The republisher can map the ROS values to single field (e.g. ``'fruit=apple'``) or to an array of fields (e.g. ``'fruits=[{fruit1: apple, fruit2: orange}, {fruit1: melon, fruit2: apple}]'``). The former is useful to capture simple fields and the latter to get data from an array of values.
 
+### Single field: mapping options
+
+When republishing a single field, you can include a set of ``mapping_options`` for each ``mapping``. These include:
+
+* `filter`: a lambda expression that can be used to whether to publish the value or not based on a condition. For example, if you'd like to republish only String values that are different than ``SPAMMY STRING`` only, you can do it with:
+
+  ```yaml
+  mapping_options:
+    filter: 'lambda x: (x != "SPAMMY STRING")'
+  ```
+
 ### Array of fields: mapping options
 
 When republishing an array of fields, you can include a set of ``mapping_options`` for each ``mapping``. These include:

--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -61,7 +61,7 @@ The republisher can map the ROS values to single field (e.g. ``'fruit=apple'``) 
 
 When republishing a single field, you can include a set of ``mapping_options`` for each ``mapping``. These include:
 
-* `filter`: a lambda expression that can be used to whether to publish the value or not based on a condition. For example, if you'd like to republish only String values that are different than ``SPAMMY STRING`` only, you can do it with:
+* `filter`: a lambda expression that can be used to control whether or not the value is published based on a condition. For example, if you'd like to republish only String values that are different than ``SPAMMY STRING``, you can do it with:
 
   ```yaml
   mapping_options:

--- a/inorbit_republisher/config/example.yaml
+++ b/inorbit_republisher/config/example.yaml
@@ -4,6 +4,8 @@ republishers:
   mappings:
   - field: "msg"
     mapping_type: "single_field"
+    mapping_options:
+      filter: 'lambda x: x != "Go"'
     out:
       topic: "/inorbit/custom_data/0"
       key: "rosout_msg"

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -89,6 +89,7 @@ def main():
                 topic = mapping['out']['topic']
 
                 if mapping_type == MAPPING_TYPE_SINGLE_FIELD:
+                    # TODO(adamantivm) Exception handling
                     field = extract_value(msg, attrgetter(mapping['field']))
                     val = process_single_field(field, mapping)
 


### PR DESCRIPTION
Adds the option to filter values before republishing, using a new 'filter' mapping_option for single values