### PR TITLE
Kinetic unify dependencies in package.xml

### DIFF
--- a/inorbit_republisher/package.xml
+++ b/inorbit_republisher/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>inorbit_republisher</name>
-  <version>0.2.3</version>
+  <version>0.2.4</version>
   <description>ROS to InOrbit topic republisher</description>
   <maintainer email="support@inorbit.ai">InOrbit</maintainer>
   <license>MIT</license>
@@ -10,16 +10,20 @@
   <build_depend>roslib</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>geometry_msgs</build_depend>
-  <build_depend>python-yaml</build_depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</depend>
+  <build_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</depend>
   <build_export_depend>rospy</build_export_depend>
   <build_export_depend>roslib</build_export_depend>
   <build_export_depend>std_msgs</build_export_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
-  <build_export_depend>python-yaml</build_export_depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</depend>
+  <build_export_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</depend>
   <exec_depend>rospy</exec_depend>
-  <exec_depend>python-rospkg</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-rospkg</depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-rospkg</depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
-  <exec_depend>python-yaml</exec_depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 2">python-yaml</depend>
+  <exec_depend condition="$ROS_PYTHON_VERSION == 3">python3-yaml</depend>
 </package>


### PR DESCRIPTION
Add conditionals to `package.xml` in order to maintain a single version of this file for both Python2 and Python3 environments.