### PR TITLE
Adding filter to JSON mappings

### DIFF
--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -119,11 +119,11 @@ The `mapping_options` for this type include:
   data: "linear_vel={\"y\": 0.00013548378774430603, \"x\": 0.0732172280550003, \"z\": 0.0}"
   ```
 
-  * `filter`: a lambda expression that can be used to control whether or not the JSON object is published based on a condition. For example, if you'd like to republish only JSON objects that have a value for the key ``important_key`` different than ``NOT IMPORTANT``, you can do it with:
+  * `filter`: a lambda expression that can be used to control whether or not the JSON object is published based on a condition. For example, if you'd like to republish only JSON objects that have a value for the key ``z`` different than ``0``, you can do it with:
 
   ```yaml
   mapping_options:
-    filter: 'lambda x: (x["important_key"] != "NOT IMPORTANT")'
+    filter: 'lambda linear_vel: (linear_vel["z"] != 0)'
   ```
 
 ## Publishing fixed values

--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -119,6 +119,13 @@ The `mapping_options` for this type include:
   data: "linear_vel={\"y\": 0.00013548378774430603, \"x\": 0.0732172280550003, \"z\": 0.0}"
   ```
 
+  * `filter`: a lambda expression that can be used to control whether or not the JSON object is published based on a condition. For example, if you'd like to republish only JSON objects that have a value for the key ``important_key`` different than ``NOT IMPORTANT``, you can do it with:
+
+  ```yaml
+  mapping_options:
+    filter: 'lambda x: (x["important_key"] != "NOT IMPORTANT")'
+  ```
+
 ## Publishing fixed values
 
 Sometimes it is also useful to publish fixed values to facilitate fleet-wide observability. It is possible to publish environment variables, package versions or fixed values using the `static_publishers` array.

--- a/inorbit_republisher/config/example.yaml
+++ b/inorbit_republisher/config/example.yaml
@@ -29,6 +29,7 @@ republishers:
     mapping_type: "json_of_fields"
     mapping_options:
       fields: ["x", "y", "z"]
+      filter: 'lambda elem: (elem["x"] > 0)'
     out:
       topic: "/inorbit/linear_vel_test"
       key: "linear_vel"

--- a/inorbit_republisher/config/example.yaml
+++ b/inorbit_republisher/config/example.yaml
@@ -29,7 +29,7 @@ republishers:
     mapping_type: "json_of_fields"
     mapping_options:
       fields: ["x", "y", "z"]
-      filter: 'lambda elem: (elem["x"] > 0)'
+      filter: 'lambda vel: (vel["x"] > 0)'
     out:
       topic: "/inorbit/linear_vel_test"
       key: "linear_vel"

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -118,7 +118,9 @@ def main():
                 elif mapping_type == MAPPING_TYPE_JSON_OF_FIELDS:
                     try:
                         val = extract_values_as_dict(msg, mapping)
-                        val = json.dumps(val)
+                        # We prevent sending a data:"key=null" to the topic
+                        if val:
+                          val = json.dumps(val)
                     except TypeError as e:
                         rospy.logwarn("Failed to serialize message: %s", e)
 
@@ -197,7 +199,8 @@ def extract_values_as_dict(msg, mapping):
             values[field] = val
         except AttributeError as e:
             rospy.logwarn('Couldn\'t get attribute %s: %s', field, e)
-    return values
+    filter_fn = mapping.get('mapping_options', {}).get('filter')
+    return values if not filter_fn or eval(filter_fn)(values) else None
 
 """
 Processes a scalar value before publishing according to mapping options

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -118,7 +118,8 @@ def main():
                 elif mapping_type == MAPPING_TYPE_JSON_OF_FIELDS:
                     try:
                         val = extract_values_as_dict(msg, mapping)
-                        # We prevent sending a data:"key=null" to the topic
+                        # extract_values_as_dict has the ability to filter messages and
+                        # returns None when an element doesn't pass the filter
                         if val:
                           val = json.dumps(val)
                     except TypeError as e:


### PR DESCRIPTION
Adds the option to filter JSON objects before republishing, using the same filter we were using for lists but applied to dicts now