### PR TITLE
Backport jsonfilter to kinetic

### DIFF
--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -119,6 +119,13 @@ The `mapping_options` for this type include:
   data: "linear_vel={\"y\": 0.00013548378774430603, \"x\": 0.0732172280550003, \"z\": 0.0}"
   ```
 
+* `filter`: a lambda expression that can be used to control whether or not the JSON object is published based on a condition. For example, if you'd like to republish only JSON objects that have a value for the key ``z`` different than ``0``, you can do it with:
+
+  ```yaml
+  mapping_options:
+    filter: 'lambda linear_vel: (linear_vel["z"] != 0)'
+  ```
+
 ## Publishing fixed values
 
 Sometimes it is also useful to publish fixed values to facilitate fleet-wide observability. It is possible to publish environment variables, package versions or fixed values using the `static_publishers` array.

--- a/inorbit_republisher/config/example.yaml
+++ b/inorbit_republisher/config/example.yaml
@@ -29,6 +29,7 @@ republishers:
     mapping_type: "json_of_fields"
     mapping_options:
       fields: ["x", "y", "z"]
+      filter: 'lambda vel: (vel["x"] > 0)'
     out:
       topic: "/inorbit/linear_vel_test"
       key: "linear_vel"

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -118,7 +118,10 @@ def main():
                 elif mapping_type == MAPPING_TYPE_JSON_OF_FIELDS:
                     try:
                         val = extract_values_as_dict(msg, mapping)
-                        val = json.dumps(val)
+                        # extract_values_as_dict has the ability to filter messages and
+                        # returns None when an element doesn't pass the filter
+                        if val:
+                          val = json.dumps(val)
                     except TypeError as e:
                         rospy.logwarn("Failed to serialize message: %s", e)
 
@@ -197,7 +200,8 @@ def extract_values_as_dict(msg, mapping):
             values[field] = val
         except AttributeError as e:
             rospy.logwarn('Couldn\'t get attribute %s: %s', field, e)
-    return values
+    filter_fn = mapping.get('mapping_options', {}).get('filter')
+    return values if not filter_fn or eval(filter_fn)(values) else None
 
 """
 Processes a scalar value before publishing according to mapping options


### PR DESCRIPTION
Demo:
/cmd_vel topic (we can see here that the robot is publishing negative linear vel (-x)):
![image](https://user-images.githubusercontent.com/67295004/192363350-52273f89-9657-4902-a437-21a1909f0e0b.png)
/inorbit/linear_vel_test (the republisher topic, here only linear vel with x>0 should be published):
![image](https://user-images.githubusercontent.com/67295004/192363508-bd9a91a1-f505-40c7-8405-19f9d406cefe.png)

So we can see the changes are working as expected in kinetic
