### PR TITLE
add an explicit latched property for republishers

### DIFF
--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -39,6 +39,17 @@ Create a YAML config file specifying the mappings you would like to use using th
       out:
         topic: "/inorbit/linear_vel_test"
         key: "linear_vel"
+  - topic: "/initialpose"
+    latched: true
+    msg_type: "geometry_msgs/PoseWithCovarianceStamped"
+    mappings:
+    - field: "pose.pose.position"
+      mapping_type: "single_field"
+      mapping_options:
+        fields: ["x", "y", "z"]
+      out:
+        topic: "/inorbit/initial_pose_test"
+        key: "initial_pose"
   static_publishers:
   - value: "this is a fixed string"
     out:
@@ -133,6 +144,16 @@ Sometimes it is also useful to publish fixed values to facilitate fleet-wide obs
 See the included example configuration in `config/example.yaml` for specific examples.
 
 These values will be published as latched and delivered only once every time a subscriber connects to the republisher.
+
+## Publishing latched values
+
+Republishing latched topics requires a special treatment to make sure that the agent receives data properly (this case is prone to subscription issues depending on nodes startup timing). To achieve this, add a flag to the input topic config indicating that it is latched:
+
+```yaml
+republishers:
+  - topic: "/map_metadata"
+    latched: true
+```
 
 ## Building and running locally
 

--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -145,7 +145,7 @@ These values will be published as latched and delivered only once every time a s
 
 ## Publishing latched values
 
-Republishing latched topics requires a special treatment to make sure that the agent receives data properly (this case is prone to subscription issues depending on nodes startup timing). To achieve this, add a flag to the input topic config indicating that it is latched:
+Republishing latched topics requires a special treatment to make sure that all latched messages, from each mapping defined, get published when a new subscriber connects to the output topic (this case is prone to subscription issues depending on nodes startup timing). To achieve this, add a flag to the input topic config indicating that it is latched:
 
 ```yaml
 republishers:

--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -39,17 +39,15 @@ Create a YAML config file specifying the mappings you would like to use using th
       out:
         topic: "/inorbit/linear_vel_test"
         key: "linear_vel"
-  - topic: "/initialpose"
+  - topic: "/map_metadata"
     latched: true
-    msg_type: "geometry_msgs/PoseWithCovarianceStamped"
+    msg_type: "nav_msgs/MapMetaData"
     mappings:
-    - field: "pose.pose.position"
+    - field: "resolution"
       mapping_type: "single_field"
-      mapping_options:
-        fields: ["x", "y", "z"]
       out:
-        topic: "/inorbit/initial_pose_test"
-        key: "initial_pose"
+        topic: "/inorbit/map_res_test"
+        key: "map_resolution"
   static_publishers:
   - value: "this is a fixed string"
     out:

--- a/inorbit_republisher/config/example.yaml
+++ b/inorbit_republisher/config/example.yaml
@@ -34,6 +34,16 @@ republishers:
       topic: "/inorbit/linear_vel_test"
       key: "linear_vel"
 
+- topic: "/map_metadata"
+  latched: true
+  msg_type: "nav_msgs/MapMetaData"
+  mappings:
+  - field: "resolution"
+    mapping_type: "single_field"
+    out:
+      topic: "/inorbit/map_res_test"
+      key: "map_resolution"
+
 static_publishers:
 - value_from:
     package_version: "rospy"

--- a/inorbit_republisher/package.xml
+++ b/inorbit_republisher/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>inorbit_republisher</name>
-  <version>0.2.5</version>
+  <version>0.3.0</version>
   <description>ROS to InOrbit topic republisher</description>
   <maintainer email="support@inorbit.ai">InOrbit</maintainer>
   <license>MIT</license>

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -34,7 +34,6 @@ import os
 from std_msgs.msg import String
 from roslib.message import get_message_class
 from operator import attrgetter
-import logging
 
 # Types of mappings allowed
 MAPPING_TYPE_SINGLE_FIELD = "single_field"


### PR DESCRIPTION
Adds basic latched topic remapping functionality.

When multiple input latched topics are mapped to the same output topic, only one message will be latched for subscriptors connecting to this output topic.
Even if we try using a difference instance of `rospy.Publisher` for each input topic we're mapping, under the covers rospy uses a global singleton and thus re-uses the same publisher for all topics, leading to a single latched topic being stored and sent to subscribers.

In this MR, we force the use of a small wrapper `LatchPublisher` class for each input topic, so that the last message from each latched input topic is stored and forwarded to subscribers of the output topic.

Since having a different instance of `LatchPublisher` per mapping is not efficient, input topics that are latched and should follow this behavior must be explicitly marked with the `latched` property in its mapping.