### PR TITLE
Fix variable shadowing on message `callback` method

### DIFF
--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -17,7 +17,7 @@ Create a YAML config file specifying the mappings you would like to use using th
     - field: "num_oranges"
       mapping_type: "single_field"
       out:
-        topic: "/inorbit/custom_data/"
+        topic: "/inorbit/custom_data"
         key: "oranges"
   - topic: "/hardware/status"
     msg_type: "hw_msgs/msg/HardwareStatus"
@@ -28,7 +28,7 @@ Create a YAML config file specifying the mappings you would like to use using th
         filter: 'lambda x: (x.status == 1)'
       mapping_type: "array_of_fields"
       out:
-        topic: "/inorbit/custom_data/"
+        topic: "/inorbit/custom_data"
         key: "hardware_error"
   - topic: "/cmd_vel"
     qos: 10
@@ -45,12 +45,12 @@ Create a YAML config file specifying the mappings you would like to use using th
   static_publishers:
   - value: "this is a fixed string"
     out:
-      topic: "/inorbit/custom_data/"
+      topic: "/inorbit/custom_data"
       key: "greeting"
   - value_from:
       environment_variable: "PATH"
     out:
-      topic: "/inorbit/custom_data/"
+      topic: "/inorbit/custom_data"
       key: "env_path"
 ```
 

--- a/inorbit_republisher/README.md
+++ b/inorbit_republisher/README.md
@@ -118,7 +118,7 @@ The `mapping_options` for this type include:
 
   would output a JSON object with the fields as keys with their respective values for the message
 
-  ```
+  ```text
   data: "linear_vel={\"y\": 0.00013548378774430603, \"x\": 0.0732172280550003, \"z\": 0.0}"
   ```
 
@@ -141,11 +141,22 @@ These values will be published as latched and delivered only once every time a s
 
 Find below instructions for building the package and running the node using the the code on the workspace (see also [colcon](https://colcon.readthedocs.io/en/released/reference/verb/build.html)).
 
+### Start ROS2 docker container (optional)
+
+You can run the commands below for building and running the republisher inside a docker container.
+
+```bash
+docker run -ti --rm \
+  --workdir /root/ros2_ws/ \
+  -v .:/root/ros2_ws/src/inorbit_republisher \
+  osrf/ros:foxy-desktop
+```
+
 ### Build
 
 ```bash
 cd ~/ros2_ws
-colcon build --packages-select inorbit_republisher
+colcon build --packages-select inorbit_republisher --symlink-install
 ```
 
 ### Run

--- a/inorbit_republisher/inorbit_republisher/republisher.py
+++ b/inorbit_republisher/inorbit_republisher/republisher.py
@@ -142,9 +142,7 @@ def main(args = None):
                         node.get_logger().warning(f"Failed to serialize message: {e}")
 
                 if val is not None:
-                    msg = String()
-                    msg.data = f"{key}={val}"
-                    pubs[topic].publish(msg)
+                    pubs[topic].publish(String(data=f"{key}={val}"))
 
         in_topic = repub['topic']
         # Reads QoS from the topic settings
@@ -179,9 +177,7 @@ def main(args = None):
         # TODO(adamantivm) Make these values latched
         if val is not None:
             pub = node.create_publisher(String, topic, 10)
-            msg = String()
-            msg.data = f"{key}={val}"
-            pub.publish(msg)
+            pub.publish(String(data=f"{key}={val}"))
 
     node.get_logger().info("Republisher started")
     rclpy.spin(node)


### PR DESCRIPTION
# Changes

- Fixed variable issue that caused callback parameter `msg` to be overwritten with a `String` object when processing more than 1 mapping.
- Minor styling changes to README and fixed example `yaml` output topics
  - Also added an optional section for spinning a docker container for ROS

# Test

## How to reproduce

Start the republisher with the configuration below that uses standard [DiagnosticStatus](https://docs.ros2.org/foxy/api/diagnostic_msgs/msg/DiagnosticStatus.html) messages:

```yaml
republishers:
- topic: "/fake_diags"
  msg_type: "diagnostic_msgs/msg/DiagnosticStatus"
  mappings:
  - field: "name"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data"
      key: "diagnostic_status_name"
  - field: "message"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data"
      key: "diagnostic_status_message"
```

Publish a `DiagnosticStatus` message with `name` and `message`:

```bash
ros2 topic pub -1 /fake_diags diagnostic_msgs/msg/DiagnosticStatus "{name: 'Foo', message: 'Bar'}"
```

The republisher node crashes with the following error:

```text
[republisher-1] Traceback (most recent call last):
[republisher-1]   File "/root/ros2_ws/install/inorbit_republisher/lib/inorbit_republisher/republisher", line 11, in <module>
[republisher-1]     load_entry_point('inorbit-republisher', 'console_scripts', 'republisher')()
[republisher-1]   File "/root/ros2_ws/build/inorbit_republisher/inorbit_republisher/republisher.py", line 187, in main
[republisher-1]     rclpy.spin(node)
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/__init__.py", line 191, in spin
[republisher-1]     executor.spin_once()
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 719, in spin_once
[republisher-1]     raise handler.exception()
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/task.py", line 239, in __call__
[republisher-1]     self._handler.send(None)
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 429, in handler
[republisher-1]     await call_coroutine(entity, arg)
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 354, in _execute_subscription
[republisher-1]     await await_or_execute(sub.callback, msg)
[republisher-1]   File "/opt/ros/foxy/lib/python3.8/site-packages/rclpy/executors.py", line 118, in await_or_execute
[republisher-1]     return callback(*args)
[republisher-1]   File "/root/ros2_ws/build/inorbit_republisher/inorbit_republisher/republisher.py", line 124, in callback
[republisher-1]     field = extract_value(msg, attrgetter(mapping['field']))
[republisher-1]   File "/root/ros2_ws/build/inorbit_republisher/inorbit_republisher/republisher.py", line 200, in extract_value
[republisher-1]     val = getter_fn(msg)
[republisher-1] AttributeError: 'String' object has no attribute 'message'
```

## Demo

After the fix, the messages are published to `/inorbit/custom_data` topic:

```bash
$ ros2 topic echo /inorbit/custom_data
data: diagnostic_status_name=Foo
---
data: diagnostic_status_message=Bar
---
```
