### PR TITLE
Fix LatchPublisher peer_subscribe to publish all key-values

### DIFF
--- a/inorbit_republisher/launch/example.launch
+++ b/inorbit_republisher/launch/example.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="inorbit_republisher" pkg="inorbit_republisher" type="republisher.py">
+  <node name="inorbit_republisher" pkg="inorbit_republisher" type="republisher.py" output="screen">
     <param name="config" textfile="$(find inorbit_republisher)/config/example.yaml" />
   </node>
 </launch>

--- a/inorbit_republisher/launch/example.launch
+++ b/inorbit_republisher/launch/example.launch
@@ -1,5 +1,5 @@
 <launch>
-  <node name="inorbit_republisher" pkg="inorbit_republisher" type="republisher.py" output="screen">
+  <node name="inorbit_republisher" pkg="inorbit_republisher" type="republisher.py">
     <param name="config" textfile="$(find inorbit_republisher)/config/example.yaml" />
   </node>
 </launch>

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -55,7 +55,7 @@ as complexity increases.
 """
 def main():
     # Start the ROS node
-    rospy.init_node('inorbit_republisher', anonymous=True)
+    rospy.init_node('inorbit_republisher', anonymous=True, log_level=rospy.INFO)
 
     # Read republisher configuration from the 'config_file' or 'config' parameter
     # TODO(adamantivm) Error handling and schema checking
@@ -113,7 +113,6 @@ def main():
 
         # Prepare callback to relay messages through InOrbit custom data
         def callback(msg, repub=repub, in_topic=in_topic, latched=latched):
-
             for mapping in repub['mappings']:
                 key = mapping['out']['key']
                 val = None
@@ -298,15 +297,19 @@ For more details see: https://github.com/ros/ros_comm/issues/146#issuecomment-30
 class LatchPublisher(rospy.Publisher, rospy.SubscribeListener):
     def __init__(self, name, data_class, tcp_nodelay=False, headers=None, queue_size=None):
         super(LatchPublisher, self).__init__(name, data_class=data_class, tcp_nodelay=tcp_nodelay, headers=headers, queue_size=queue_size, subscriber_listener=self, latch=False)
-        self.message = None
+        self.latch_publisher = super(LatchPublisher, self)
+        # Store all kv messages when publising.
+        self.message = dict()
 
     def publish(self, msg):
-        self.message = msg
-        super(LatchPublisher, self).publish(msg)
+        # Map key to message so they can be all published when a peer subscribes.
+        self.message[msg.split('=')[0]] = msg
+        self.latch_publisher.publish(msg)
 
     def peer_subscribe(self, resolved_name, publish, publish_single):
-        if self.message is not None:
-            super(LatchPublisher, self).publish(self.message)
+        # Publish all key-values when a peer subscribes.
+        for v in self.message.values():
+            self.latch_publisher.publish(v)
 
 if __name__ == '__main__':
     try:

--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -298,7 +298,7 @@ class LatchPublisher(rospy.Publisher, rospy.SubscribeListener):
     def __init__(self, name, data_class, tcp_nodelay=False, headers=None, queue_size=None):
         super(LatchPublisher, self).__init__(name, data_class=data_class, tcp_nodelay=tcp_nodelay, headers=headers, queue_size=queue_size, subscriber_listener=self, latch=False)
         self.latch_publisher = super(LatchPublisher, self)
-        # Store all kv messages when publising.
+        # Store all kv messages when publishing.
         self.message = dict()
 
     def publish(self, msg):


### PR DESCRIPTION
# Changes

Fix `LatchPublisher` publish method to avoid overriding `message` property when publishing messages. Also extended `peer_subscribe` to publish all key-values when a peer subscribes.

See https://docs.ros.org/en/melodic/api/rospy/html/rospy.topics.SubscribeListener-class.html

## How to reproduce

Republisher configuration file

```
republishers:
- topic: "/foo"
  msg_type: "sensor_msgs/Temperature"
  latched: true
  mappings:
  - field: "temperature"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data/0"
      key: "temperature"
  - field: "variance"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data/0"
      key: "variance"
```

Use the following script to publish a single latched message and keep the node running forever

```
#!/usr/bin/env python

import rospy
from sensor_msgs.msg import Temperature

def talker():
    pub = rospy.Publisher('/foo', Temperature, queue_size=10, latch=True)
    rospy.init_node('talker', anonymous=True)

    msg = Temperature(temperature=1.0, variance=2.0)
    rospy.loginfo(msg)
    pub.publish(msg)

    rate = rospy.Rate(10) # 10hz
    while not rospy.is_shutdown():
        rate.sleep()

if __name__ == '__main__':
    try:
        talker()
    except rospy.ROSInterruptException:
        pass
```

Subscribe to the `/inorbit/custom_data/0` topic and start the republisher `roslaunch inorbit_republisher example.launch`. Only the last `key` will be published.

```
data: "variance=2.0"                             
---                                              
data: "variance=2.0"                             
---                                              
data: "variance=2.0"                             
---                                              
data: "variance=2.0"                             
```