### PR TITLE
Fix LatchPublisher publish to handle ROS String messages

### DIFF
--- a/inorbit_republisher/scripts/republisher.py
+++ b/inorbit_republisher/scripts/republisher.py
@@ -148,7 +148,7 @@ def main():
 
                 if val is not None:
                     pub_key = "{}+{}".format(topic, in_topic) if latched else topic
-                    pubs[pub_key].publish("{}={}".format(key, val))
+                    pubs[pub_key].publish(String("{}={}".format(key, val)))
 
 
         # subscribe
@@ -303,7 +303,7 @@ class LatchPublisher(rospy.Publisher, rospy.SubscribeListener):
 
     def publish(self, msg):
         # Map key to message so they can be all published when a peer subscribes.
-        self.message[msg.split('=')[0]] = msg
+        self.message[msg.data.split('=')[0]] = msg
         self.latch_publisher.publish(msg)
 
     def peer_subscribe(self, resolved_name, publish, publish_single):


### PR DESCRIPTION
# Changes
Fix `LatchPublisher` publish method for properly handling `std_msgs/String` messages and adapted `callback` method to publish `std_msgs/String` messages instead of plain strings.

This is a continuation of https://github.com/inorbit-ai/ros_inorbit_samples/pull/25, please refer to it for complete testing instructions.

# Demo

Republisher configuration

```
republishers:
- topic: "/foo"
  msg_type: "sensor_msgs/Temperature"
  latched: true
  mappings:
  - field: "temperature"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data/0"
      key: "temperature"
  - field: "variance"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data/0"
      key: "variance"
static_publishers:
- value: "this is a fixed string"
  out:
    topic: "/inorbit/custom_data/0"
    key: "greeting"
- value_from:
    environment_variable: "PATH"
  out:
    topic: "/inorbit/custom_data/0"
    key: "env_path"
```

Before the fix:

![image](https://github.com/user-attachments/assets/48aba0a4-65aa-4a3f-936a-771683bc244e)

After the fix:

![image](https://github.com/user-attachments/assets/eb28e310-3fc8-4463-b590-db0e7d73482e)


