### PR TITLE
Add on_change option for publishing data only on change

### DIFF
--- a/inorbit_republisher/inorbit_republisher/republisher.py
+++ b/inorbit_republisher/inorbit_republisher/republisher.py
@@ -90,6 +90,7 @@ def main(args = None):
     # Dictionary of subscriber instances by topic name
     subs = {}
 
+    last_data = {}
     # TODO(adamantivm) Port ability to publish package versions from ROS 1 Noetic to ROS 2 Foxy
     # # In case we want to query ROS package options
     # rospack = rospkg.RosPack()
@@ -153,6 +154,11 @@ def main(args = None):
                         node.get_logger().warning(f"Failed to serialize message: {e}")
 
                 if val is not None:
+                    if repub.get("on_change"):
+                        uniq_key = f"{topic}:{key}"
+                        if last_data.get(uniq_key) == str(val):
+                            return
+                        last_data[uniq_key] = str(val)
                     pubs[topic].publish(String(data=f"{key}={val}"))
 
         in_topic = repub['topic']


### PR DESCRIPTION
Add support for 'on_change' configuration option in republisher mappings to publish messages only when the value changes, reducing unnecessary network traffic and improving performance.

How-To-Test:
- edit your config yaml to set the `on_change` flat to true for a topic:
```
- topic: "/test"
  msg_type: "std_msgs/msg/String"
  on_change: true
  mappings:
  - field: "data"
    mapping_type: "single_field"
    out:
      topic: "/inorbit/custom_data"
      key: "test"
```
- subscribe to `/inorbit/custom_data`
`ros2 topic echo /inorbit/custom_data`
- publish a message on that topic: 
`ros2 topic pub /test std_msgs/msg/String "data: abcd"`
- the data test is only send once
- stop the publisher, change the data string and start it again
- the data is send once with the new string